### PR TITLE
Contain overscroll in map preview.

### DIFF
--- a/src/components/LocalGame/Maps/Preview.css
+++ b/src/components/LocalGame/Maps/Preview.css
@@ -2,6 +2,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    overscroll-behavior: contain;
 
     border: 1px solid #808080;
 }


### PR DESCRIPTION
When zooming in and out on the map previews, the scroll is not contained (at least for me on Arch Linux + Wayland), with this patch the scroll event is contained to the preview and it works like I would expect it to.